### PR TITLE
Shop PT1

### DIFF
--- a/_scenes/card_shop_UI.tscn
+++ b/_scenes/card_shop_UI.tscn
@@ -1,0 +1,26 @@
+[gd_scene load_steps=2 format=3 uid="uid://b2ygkqp3wer5l"]
+
+[ext_resource type="Script" uid="uid://bjtfugcp1ssx8" path="res://_scripts/shop/card_shop_ui.gd" id="1_yata5"]
+
+[node name="CardShopUI" type="Node2D"]
+
+[node name="Control" type="Control" parent="."]
+layout_mode = 3
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -20.0
+offset_top = -20.0
+offset_right = 20.0
+offset_bottom = 20.0
+grow_horizontal = 2
+grow_vertical = 2
+script = ExtResource("1_yata5")
+
+[node name="GridContainer" type="GridContainer" parent="Control"]
+layout_mode = 0
+offset_right = 400.0
+offset_bottom = 400.0
+columns = 3

--- a/_scripts/card_shop.gd
+++ b/_scripts/card_shop.gd
@@ -1,0 +1,43 @@
+extends Node
+
+# The source deck used to draw cards to fill the shop grid.
+var shop_source_deck: Array[CardResource]
+
+var current_grid_cards: Array[Card] = []
+var input_active: bool = false
+
+const CARD = preload("uid://c3e8058lwu0a")
+
+func fill_shop_deck(pack_resources: Array[CardPackResource]) -> void:
+	for pack_res in pack_resources:
+		if pack_res:
+			var card_map: Dictionary = pack_res.card_resources
+			
+			# Loop through the Dict of CardResource keys and their quantities (values)
+			for card_resource in pack_res.card_resources.keys():
+				var count: int = card_map[card_resource]
+				for _i in range(count):
+					shop_source_deck.append(card_resource)
+	print("CardShop: Initialized deck with ", shop_source_deck, " card pack(s).")
+
+func set_input_active(is_active: bool) -> void:
+	input_active = is_active
+	print("CardShop: Input is now active: ", input_active)
+	
+func return_six_cards() -> Array[Card]:
+	for i in range(6):
+		var card_res: CardResource = shop_source_deck.pop_front()
+		var new_card: Card = CARD.instantiate()
+	
+		new_card.resource = card_res
+		current_grid_cards.append(new_card)
+	print("CardShop: Drew ", current_grid_cards.size(), " cards for the grid.")
+	return current_grid_cards
+# Called when the node enters the scene tree for the first time.
+func _ready() -> void:
+	pass # Replace with function body.
+
+
+# Called every frame. 'delta' is the elapsed time since the previous frame.
+func _process(delta: float) -> void:
+	pass

--- a/_scripts/card_shop.gd.uid
+++ b/_scripts/card_shop.gd.uid
@@ -1,0 +1,1 @@
+uid://bsrtod2rmmql6

--- a/_scripts/shop/card_shop_ui.gd
+++ b/_scripts/shop/card_shop_ui.gd
@@ -1,0 +1,37 @@
+extends Control
+class_name CardShopUI
+
+@onready var grid_container: GridContainer = $GridContainer
+
+func display_cards(cards_to_display: Array[Card]) -> void:
+	for child in grid_container.get_children():
+		child.queue_free()
+		
+	for card_instance in cards_to_display:
+		var card_slot_wrapper = Control.new()
+		card_slot_wrapper.name = "CardSlot_" + str(grid_container.get_child_count())
+		# Change to not ignore when users buy the card
+		card_slot_wrapper.mouse_filter = Control.MOUSE_FILTER_IGNORE
+		card_slot_wrapper.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+		card_slot_wrapper.size_flags_vertical = Control.SIZE_EXPAND_FILL
+		
+		# remove from any previous parent first
+		if card_instance.get_parent():
+			card_instance.get_parent().remove_child(card_instance)
+		
+		card_slot_wrapper.add_child(card_instance)
+		grid_container.add_child(card_slot_wrapper)
+	print("CardShopUI: Grid display updated with ", grid_container.get_child_count(), " cards.")
+
+# Called when the node enters the scene tree for the first time.
+func _ready() -> void:
+	call_deferred("_setup_shop_cards")
+	
+func _setup_shop_cards() -> void:
+	var initial_cards: Array[Card] = CardShop.return_six_cards()
+	print("initial cards", initial_cards)
+	display_cards(initial_cards)
+	
+# Called every frame. 'delta' is the elapsed time since the previous frame.
+func _process(delta: float) -> void:
+	pass

--- a/_scripts/shop/card_shop_ui.gd.uid
+++ b/_scripts/shop/card_shop_ui.gd.uid
@@ -1,0 +1,1 @@
+uid://bjtfugcp1ssx8

--- a/external_work/grace/multiplayer_grace.tscn
+++ b/external_work/grace/multiplayer_grace.tscn
@@ -1,0 +1,65 @@
+[gd_scene load_steps=10 format=3 uid="uid://dlvudfcojdl6"]
+
+[ext_resource type="Script" uid="uid://cr72hv20q381p" path="res://external_work/ryan/game_manager.gd" id="1_rbc2s"]
+[ext_resource type="Script" uid="uid://cg5eo4ycbga2u" path="res://_scripts/resources/CardResource.gd" id="2_g7jej"]
+[ext_resource type="Resource" uid="uid://dp3k57niax0qb" path="res://cards/LilGuy.tres" id="3_hrdlf"]
+[ext_resource type="Resource" uid="uid://bwgk83gwvfr8w" path="res://cards/RockBlock.tres" id="4_b7kiy"]
+[ext_resource type="Resource" uid="uid://b66r18jp8ponq" path="res://card_packs/FromNavaPack.tres" id="5_q6vt0"]
+[ext_resource type="Script" uid="uid://div70lvrir1m0" path="res://external_work/ryan/CardPackResource.gd" id="6_fj6jc"]
+[ext_resource type="PackedScene" uid="uid://bgrqj32tibok0" path="res://_scenes/rift_grid.tscn" id="8_wkkp3"]
+[ext_resource type="PackedScene" uid="uid://d1b1m0y144lgx" path="res://_scenes/player_hand.tscn" id="9_yq2lg"]
+[ext_resource type="PackedScene" uid="uid://b2ygkqp3wer5l" path="res://_scenes/card_shop_ui.tscn" id="10_vlbaj"]
+
+[node name="MultiplayerScene" type="Control"]
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+mouse_filter = 2
+script = ExtResource("1_rbc2s")
+cards = Array[ExtResource("2_g7jej")]([ExtResource("3_hrdlf"), ExtResource("3_hrdlf"), ExtResource("3_hrdlf"), ExtResource("3_hrdlf"), ExtResource("4_b7kiy")])
+card_pack = ExtResource("5_q6vt0")
+shop_initial_packs = Array[ExtResource("6_fj6jc")]([ExtResource("5_q6vt0"), ExtResource("5_q6vt0")])
+
+[node name="RiftGrid" parent="." instance=ExtResource("8_wkkp3")]
+layout_mode = 1
+anchors_preset = 5
+anchor_top = 0.0
+anchor_bottom = 0.0
+offset_top = 377.99997
+offset_bottom = 377.99997
+grow_vertical = 1
+scale = Vector2(0.95, 0.95)
+
+[node name="Control" type="Control" parent="."]
+layout_mode = 1
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+grow_horizontal = 2
+grow_vertical = 2
+
+[node name="Camera2D" type="Camera2D" parent="Control"]
+
+[node name="player_hand" parent="Control" instance=ExtResource("9_yq2lg")]
+position = Vector2(0, 408)
+scale = Vector2(0.9, 0.9)
+
+[node name="next_turn_button" type="Button" parent="."]
+layout_mode = 1
+anchors_preset = 1
+anchor_left = 1.0
+anchor_right = 1.0
+offset_left = -86.0
+offset_bottom = 31.0
+grow_horizontal = 0
+text = "Next Turn"
+
+[node name="CardShop" parent="." instance=ExtResource("10_vlbaj")]
+position = Vector2(93, 242)
+
+[connection signal="pressed" from="next_turn_button" to="." method="_on_next_turn_button_pressed"]

--- a/external_work/ryan/game_manager.gd
+++ b/external_work/ryan/game_manager.gd
@@ -3,13 +3,14 @@ class_name GameManager
 
 @export var cards: Array[CardResource]
 @export var card_pack: CardPackResource
-
+@export var shop_initial_packs: Array[CardPackResource]
 @onready var player_hand: PlayerHand = $Control/player_hand
 @onready var rift_grid: RiftGrid = $RiftGrid
 const CARD = preload("uid://c3e8058lwu0a")
 
 
 func _ready() -> void:
+	CardShop.fill_shop_deck(shop_initial_packs)
 	call_deferred("_after_ready")
 
 func _after_ready() -> void:

--- a/project.godot
+++ b/project.godot
@@ -20,11 +20,7 @@ config/icon="res://icon.svg"
 GNM="*res://external_work/ryan/network_manager.gd"
 Noray="*res://addons/netfox.noray/noray.gd"
 PacketHandshake="*res://addons/netfox.noray/packet-handshake.gd"
-
-[display]
-
-window/size/viewport_width=1920
-window/size/viewport_height=1080
+CardShop="*res://_scripts/card_shop.gd"
 
 [dotnet]
 


### PR DESCRIPTION
Part 1 Iteration (Part 2 coming up!)
You can see example scene in externalWork > grace > multiplayer_grace.tsn

Request: 
A script, likely called card_shop.gd, that holds a class, can be called "CardShop", that is a singleton that can be referenced for filling up its CardSet with an input of Array[CardPackResource]. And a function that can be used to allow input on the CardShop or not (used to prevent a networked player from interacting with the CardShop when it is not on their turn)

Implemented so far
- `game_manager.gd` pass `Array[CardPackResource]` to card_shop's `fill_shop_deck`
- `card_shop.gd` a singleton/global class that is added to the autoloader (project settings). it prefills the shop deck
-- `return_six_cards()` returns 6 cards to be used in UI (to see it in UI, you must drag the `card_shop_ui.tsn` node into your scene
- `card_shop_ui.gd` displays the 6 cards after `onReady()`

<img width="1913" height="1019" alt="image" src="https://github.com/user-attachments/assets/d75f9d02-b281-4c79-b8e8-2e4cb0b90ed3" />
